### PR TITLE
Center modal for the One themes

### DIFF
--- a/styles/encourage.less
+++ b/styles/encourage.less
@@ -20,3 +20,11 @@
   opacity: 0;
   transition: visibility 0s 1s, opacity 1s ease-in-out;
 }
+
+// Centering for the One themes
+.theme-one-dark-ui,
+.theme-one-light-ui {
+  .encourage {
+    margin-left: auto !important;
+  }
+}


### PR DESCRIPTION
Because the One themes use a custom backdrop (dark background), the positioning is a bit different than other themes. This PR adds a small fix.

![screen shot 2016-06-08 at 12 20 31 pm](https://cloud.githubusercontent.com/assets/378023/15881791/becb93ae-2d73-11e6-8a07-2151117c0657.png)

Fixes #5 