### PR TITLE
Make encouragements configurable

### DIFF
--- a/lib/config-schema.json
+++ b/lib/config-schema.json
@@ -1,0 +1,29 @@
+{
+  "encouragementList": {
+    "title": "Encouragement List",
+    "description": "The list from which encouragements will be selected.",
+    "type": "array",
+    "default": [
+      "Nice Job! 🎇",
+      "Way to go! ✨",
+      "Wow, nice change! 💗",
+      "So good! 💖",
+      "Bravo! 👏",
+      "You rock! 🚀",
+      "Well done! 🎉",
+      "I see what you did there! 🙏",
+      "Genius work! 🍩",
+      "Thumbs up! 👍",
+      "Coding win! 🍸",
+      "FTW! ⚡️",
+      "Yep! 🙆",
+      "Nnnnnnnailed it! ✌",
+      "You\"re good enough! 😎",
+      "You\"re smart enough! 💫",
+      "People like you! 💞"
+    ],
+    "items": {
+      "type": "string"
+    }
+  }
+}

--- a/lib/encourage.js
+++ b/lib/encourage.js
@@ -2,6 +2,7 @@
 
 import EncourageAtomView from './encourage-view';
 import { CompositeDisposable } from 'atom';
+import packageConfig from './config-schema.json';
 
 export default {
 
@@ -27,6 +28,7 @@ export default {
     'You\'re smart enough! 💫',
     'People like you! 💞'
   ],
+  config: packageConfig,
 
   activate(state) {
     this.encourageAtomView = new EncourageAtomView(state.encourageAtomViewState);

--- a/lib/encourage.js
+++ b/lib/encourage.js
@@ -8,27 +8,9 @@ export default {
 
   encourageAtomView: null,
   modalPanel: null,
-  subscriptions: null,
-  encouragements: [
-    'Nice Job! 🎇',
-    'Way to go! ✨',
-    'Wow, nice change! 💗',
-    'So good! 💖',
-    'Bravo! 👏',
-    'You rock! 🚀',
-    'Well done! 🎉',
-    'I see what you did there! 🙏',
-    'Genius work! 🍩',
-    'Thumbs up! 👍',
-    'Coding win! 🍸',
-    'FTW! ⚡️',
-    'Yep! 🙆',
-    'Nnnnnnnailed it! ✌',
-    'You\'re good enough! 😎',
-    'You\'re smart enough! 💫',
-    'People like you! 💞'
-  ],
   config: packageConfig,
+  subscriptions: null,
+  encouragements: [], // Initial state can be drawn from config
 
   activate(state) {
     this.encourageAtomView = new EncourageAtomView(state.encourageAtomViewState);
@@ -48,6 +30,8 @@ export default {
         this.subscriptions.add(savedSubscription);
         this.subscriptions.add(editor.onDidDestroy(() => savedSubscription.dispose()));
       }));
+
+    this.subscriptions.add(this.subscribeToConfigChanges());
   },
 
   deactivate() {
@@ -60,6 +44,20 @@ export default {
     return {
       encourageAtomViewState: this.encourageAtomView.serialize()
     };
+  },
+
+  subscribeToConfigChanges() {
+    const subscriptions = new CompositeDisposable();
+
+    const encouragementListObserver = atom.config.observe(
+      'encourage.encouragementList',
+      (value) => {
+        console.log('EncourageAtom detected a config change!');
+        this.encouragements = value;
+      });
+    subscriptions.add(encouragementListObserver);
+
+    return subscriptions;
   },
 
   getRandomEncouragement() {


### PR DESCRIPTION
Addresses #3: Adds atom package configuration, allowing you to enter a comma-separated list of encouragements to pull from (as well as providing @Haacked 's cheery set of encouragements by default!)

I was unable to determine a reasonable way to update the specification to determine that the encouragements are drawn from the configuration.  It doesn't necessarily help that atom provides a lot of functionality from the global context.  Any thoughts or recommendations there?
